### PR TITLE
Fix composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,6 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "psr-0": {
-            "ZabbixApi": "build"
-        }
+        "classmap": ["build/"]
     }
 }


### PR DESCRIPTION
This lib is not psr-0 compatible. Because ".class.php" is not a psr-0 standard. So you need to use a classmap.