### PR TITLE
Fix convertToAssociatveArray() to work correct with integer object properties

### DIFF
--- a/templates/abstract.tpl.php
+++ b/templates/abstract.tpl.php
@@ -410,14 +410,14 @@ abstract class <CLASSNAME_ABSTRACT>
             return $objectArray;
 
         // loop through array and replace keys
+        $newObjectArray = array();
         foreach($objectArray as $key => $object)
         {
-            unset($objectArray[$key]);
-            $objectArray[$object->{$useObjectProperty}] = $object;
+            $newObjectArray[$object->{$useObjectProperty}] = $object;
         }
 
         // return associative array
-        return $objectArray;
+        return $newObjectArray;
     }
 
     /**


### PR DESCRIPTION
If using an object property with an integer value (e.g. serviceid) there the resulting array contains only one object. This happens because the object property's value can be the same as the array's index values.