### PR TITLE
Leverage constants from `defines.inc.php`

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -42,6 +42,7 @@ return Symfony\CS\Config\Config::create()
         '-phpdoc_params',
         '-phpdoc_to_comment',
         '-psr0',
+        '-single_quote',
         'unalign_double_arrow',
         'unalign_equals',
     ))

--- a/build/templates/abstract.tpl.php
+++ b/build/templates/abstract.tpl.php
@@ -31,7 +31,9 @@ namespace ZabbixApi;
  * Abstract class for the Zabbix API.
  */
 abstract class <CLASSNAME_ABSTRACT>
-{
+{<!START_API_CONSTANT>
+    const <PHP_CONST_NAME> = <PHP_CONST_VALUE>;
+<!END_API_CONSTANT>
     /**
      * Anonymous API functions.
      *

--- a/tests/ZabbixApiTest.php
+++ b/tests/ZabbixApiTest.php
@@ -39,6 +39,8 @@ final class ZabbixApiTest extends TestCase
     {
         $this->assertTrue(class_exists('ZabbixApi\ZabbixApi'));
 
+        $this->assertGreaterThanOrEqual(0, version_compare(ZabbixApi::ZABBIX_VERSION, '2.4'));
+
         $zabbix = new ZabbixApi('http://localhost/json_rpc.php');
 
         $defaultParams = array(
@@ -53,6 +55,7 @@ final class ZabbixApiTest extends TestCase
         $ro = new \ReflectionObject($zabbix);
 
         $this->assertGreaterThanOrEqual(360, count($ro->getMethods(\ReflectionMethod::IS_PUBLIC)));
+        $this->assertGreaterThanOrEqual(668, count($ro->getConstants()));
     }
 
     public function testUserLoginOnConsecutiveCalls()


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

<details>
<summary>Example using v4.4.0:</summary>

```php
    const ZABBIX_VERSION = '4.4.0';

    const ZABBIX_API_VERSION = '4.4.0';

    const ZABBIX_EXPORT_VERSION = '4.4';

    const ZABBIX_DB_VERSION = 4040000;

    const ZABBIX_COPYRIGHT_FROM = '2001';

    const ZABBIX_COPYRIGHT_TO = '2019';

    const ZBX_LOGIN_ATTEMPTS = 5;

    const ZBX_LOGIN_BLOCK = 30;

    const ZBX_SESSION_NAME = 'zbx_sessionid';

    const ZBX_KIBIBYTE = '1024';

    const ZBX_MEBIBYTE = '1048576';

    const ZBX_GIBIBYTE = '1073741824';

    const ZBX_MIN_PERIOD = 60;

    const ZBX_MAX_PERIOD = 63158400;

    const ZBX_MIN_INT32 = -2147483648;

    const ZBX_MAX_INT32 = 2147483647;

    const ZBX_MIN_INT64 = '-9223372036854775808';

    const ZBX_MAX_INT64 = '9223372036854775807';

    const ZBX_MAX_UINT64 = '18446744073709551615';

    const ZBX_MAX_DATE = 2147483647;

    const ZBX_PERIOD_DEFAULT_FROM = 'now-1h';

    const ZBX_PERIOD_DEFAULT_TO = 'now';

    const ZBX_MIN_TIMESHIFT = -788400000;

    const ZBX_MAX_TIMESHIFT = 788400000;

    const ZBX_FULL_DATE_TIME = 'Y-m-d H:i:s';

    const ZBX_DATE_TIME = 'Y-m-d H:i';

    const ZBX_HISTORY_PERIOD = 86400;

    const ZBX_HISTORY_SOURCE_ELASTIC = 'elastic';

    const ZBX_HISTORY_SOURCE_SQL = 'sql';

    const ELASTICSEARCH_RESPONSE_PLAIN = 0;

    const ELASTICSEARCH_RESPONSE_AGGREGATION = 1;

    const ELASTICSEARCH_RESPONSE_DOCUMENTS = 2;

    const ZBX_GRAPH_FONT_NAME = 'DejaVuSans';

    const ZBX_GRAPH_LEGEND_HEIGHT = 120;

    const ZBX_SCRIPT_TIMEOUT = 60;

    const GRAPH_YAXIS_SIDE_DEFAULT = 0;

    const ZBX_MAX_IMAGE_SIZE = self::ZBX_MEBIBYTE;

    const ZBX_UNITS_ROUNDOFF_THRESHOLD = 0.01;

    const ZBX_UNITS_ROUNDOFF_UPPER_LIMIT = 2;

    const ZBX_UNITS_ROUNDOFF_MIDDLE_LIMIT = 4;

    const ZBX_UNITS_ROUNDOFF_LOWER_LIMIT = 6;

    const ZBX_PRECISION_10 = 10;

    const ZBX_DEFAULT_INTERVAL = '1-7,00:00-24:00';

    const ZBX_SCRIPT_TYPE_CUSTOM_SCRIPT = 0;

    const ZBX_SCRIPT_TYPE_IPMI = 1;

    const ZBX_SCRIPT_TYPE_SSH = 2;

    const ZBX_SCRIPT_TYPE_TELNET = 3;

    const ZBX_SCRIPT_TYPE_GLOBAL_SCRIPT = 4;

    const ZBX_SCRIPT_EXECUTE_ON_AGENT = 0;

    const ZBX_SCRIPT_EXECUTE_ON_SERVER = 1;

    const ZBX_SCRIPT_EXECUTE_ON_PROXY = 2;

    const ZBX_FLAG_DISCOVERY_NORMAL = 0x0;

    const ZBX_FLAG_DISCOVERY_RULE = 0x1;

    const ZBX_FLAG_DISCOVERY_PROTOTYPE = 0x2;

    const ZBX_FLAG_DISCOVERY_CREATED = 0x4;

    const EXTACK_OPTION_ALL = 0;

    const EXTACK_OPTION_UNACK = 1;

    const EXTACK_OPTION_BOTH = 2;

    const WIDGET_PROBLEMS_BY_SV_SHOW_GROUPS = 0;

    const WIDGET_PROBLEMS_BY_SV_SHOW_TOTALS = 1;

    const TRIGGERS_OPTION_RECENT_PROBLEM = 1;

    const TRIGGERS_OPTION_ALL = 2;

    const TRIGGERS_OPTION_IN_PROBLEM = 3;

    const ZBX_FONT_NAME = 'DejaVuSans';

    const ZBX_AUTH_INTERNAL = 0;

    const ZBX_AUTH_LDAP = 1;

    const ZBX_AUTH_HTTP_DISABLED = 0;

    const ZBX_AUTH_HTTP_ENABLED = 1;

    const ZBX_AUTH_LDAP_DISABLED = 0;

    const ZBX_AUTH_LDAP_ENABLED = 1;

    const ZBX_AUTH_FORM_ZABBIX = 0;

    const ZBX_AUTH_FORM_HTTP = 1;

    const ZBX_AUTH_CASE_INSENSITIVE = 0;

    const ZBX_AUTH_CASE_SENSITIVE = 1;

    const ZBX_DB_DB2 = 'IBM_DB2';

    const ZBX_DB_MYSQL = 'MYSQL';

    const ZBX_DB_ORACLE = 'ORACLE';

    const ZBX_DB_POSTGRESQL = 'POSTGRESQL';

    const ZBX_DB_MAX_ID = '9223372036854775807';

    const ZBX_DB_MAX_INSERTS = 10000;

    const ZBX_SHOW_TECHNICAL_ERRORS = false;

    const PAGE_TYPE_HTML = 0;

    const PAGE_TYPE_IMAGE = 1;

    const PAGE_TYPE_XML = 2;

    const PAGE_TYPE_JS = 3;

    const PAGE_TYPE_CSS = 4;

    const PAGE_TYPE_HTML_BLOCK = 5;

    const PAGE_TYPE_JSON = 6;

    const PAGE_TYPE_JSON_RPC = 7;

    const PAGE_TYPE_TEXT_FILE = 8;

    const PAGE_TYPE_TEXT = 9;

    const PAGE_TYPE_CSV = 10;

    const PAGE_TYPE_TEXT_RETURN_JSON = 11;

    const ZBX_SESSION_ACTIVE = 0;

    const ZBX_SESSION_PASSIVE = 1;

    const ZBX_DROPDOWN_FIRST_NONE = 0;

    const ZBX_DROPDOWN_FIRST_ALL = 1;

    const T_ZBX_STR = 0;

    const T_ZBX_INT = 1;

    const T_ZBX_DBL = 2;

    const T_ZBX_RANGE_TIME = 3;

    const T_ZBX_CLR = 5;

    const T_ZBX_DBL_BIG = 9;

    const T_ZBX_DBL_STR = 10;

    const T_ZBX_TP = 11;

    const T_ZBX_TU = 12;

    const T_ZBX_ABS_TIME = 13;

    const O_MAND = 0;

    const O_OPT = 1;

    const O_NO = 2;

    const P_SYS = 0x0001;

    const P_UNSET_EMPTY = 0x0002;

    const P_CRLF = 0x0004;

    const P_ACT = 0x0010;

    const P_NZERO = 0x0020;

    const P_NO_TRIM = 0x0040;

    const P_ALLOW_USER_MACRO = 0x0080;

    const P_ALLOW_LLD_MACRO = 0x0100;

    const ZBX_URI_VALID_SCHEMES = 'http,https,ftp,file,mailto,tel,ssh';

    const VALIDATE_URI_SCHEMES = true;

    const IMAGE_FORMAT_PNG = 'PNG';

    const IMAGE_FORMAT_JPEG = 'JPEG';

    const IMAGE_FORMAT_TEXT = 'JPEG';

    const IMAGE_FORMAT_GIF = 'GIF';

    const IMAGE_TYPE_ICON = 1;

    const IMAGE_TYPE_BACKGROUND = 2;

    const ITEM_CONVERT_WITH_UNITS = 0;

    const ITEM_CONVERT_NO_UNITS = 1;

    const ZBX_SORT_UP = 'ASC';

    const ZBX_SORT_DOWN = 'DESC';

    const ZBX_TAG_COUNT_DEFAULT = 3;

    const ZBX_TCP_HEADER_DATA = "ZBXD";

    const ZBX_TCP_HEADER_VERSION = "\1";

    const ZBX_TCP_HEADER = self::ZBX_TCP_HEADER_DATA.self::ZBX_TCP_HEADER_VERSION;

    const ZBX_TCP_HEADER_LEN = 5;

    const ZBX_TCP_DATALEN_LEN = 8;

    const AUDIT_ACTION_ADD = 0;

    const AUDIT_ACTION_UPDATE = 1;

    const AUDIT_ACTION_DELETE = 2;

    const AUDIT_ACTION_LOGIN = 3;

    const AUDIT_ACTION_LOGOUT = 4;

    const AUDIT_ACTION_ENABLE = 5;

    const AUDIT_ACTION_DISABLE = 6;

    const AUDIT_RESOURCE_USER = 0;

    const AUDIT_RESOURCE_ZABBIX_CONFIG = 2;

    const AUDIT_RESOURCE_MEDIA_TYPE = 3;

    const AUDIT_RESOURCE_HOST = 4;

    const AUDIT_RESOURCE_ACTION = 5;

    const AUDIT_RESOURCE_GRAPH = 6;

    const AUDIT_RESOURCE_GRAPH_ELEMENT = 7;

    const AUDIT_RESOURCE_USER_GROUP = 11;

    const AUDIT_RESOURCE_APPLICATION = 12;

    const AUDIT_RESOURCE_TRIGGER = 13;

    const AUDIT_RESOURCE_HOST_GROUP = 14;

    const AUDIT_RESOURCE_ITEM = 15;

    const AUDIT_RESOURCE_IMAGE = 16;

    const AUDIT_RESOURCE_VALUE_MAP = 17;

    const AUDIT_RESOURCE_IT_SERVICE = 18;

    const AUDIT_RESOURCE_MAP = 19;

    const AUDIT_RESOURCE_SCREEN = 20;

    const AUDIT_RESOURCE_SCENARIO = 22;

    const AUDIT_RESOURCE_DISCOVERY_RULE = 23;

    const AUDIT_RESOURCE_SLIDESHOW = 24;

    const AUDIT_RESOURCE_SCRIPT = 25;

    const AUDIT_RESOURCE_PROXY = 26;

    const AUDIT_RESOURCE_MAINTENANCE = 27;

    const AUDIT_RESOURCE_REGEXP = 28;

    const AUDIT_RESOURCE_MACRO = 29;

    const AUDIT_RESOURCE_TEMPLATE = 30;

    const AUDIT_RESOURCE_TRIGGER_PROTOTYPE = 31;

    const AUDIT_RESOURCE_ICON_MAP = 32;

    const AUDIT_RESOURCE_DASHBOARD = 33;

    const AUDIT_RESOURCE_CORRELATION = 34;

    const AUDIT_RESOURCE_GRAPH_PROTOTYPE = 35;

    const AUDIT_RESOURCE_ITEM_PROTOTYPE = 36;

    const AUDIT_RESOURCE_HOST_PROTOTYPE = 37;

    const AUDIT_RESOURCE_AUTOREGISTRATION = 38;

    const CONDITION_TYPE_HOST_GROUP = 0;

    const CONDITION_TYPE_HOST = 1;

    const CONDITION_TYPE_TRIGGER = 2;

    const CONDITION_TYPE_TRIGGER_NAME = 3;

    const CONDITION_TYPE_TRIGGER_SEVERITY = 4;

    const CONDITION_TYPE_TIME_PERIOD = 6;

    const CONDITION_TYPE_DHOST_IP = 7;

    const CONDITION_TYPE_DSERVICE_TYPE = 8;

    const CONDITION_TYPE_DSERVICE_PORT = 9;

    const CONDITION_TYPE_DSTATUS = 10;

    const CONDITION_TYPE_DUPTIME = 11;

    const CONDITION_TYPE_DVALUE = 12;

    const CONDITION_TYPE_TEMPLATE = 13;

    const CONDITION_TYPE_EVENT_ACKNOWLEDGED = 14;

    const CONDITION_TYPE_APPLICATION = 15;

    const CONDITION_TYPE_SUPPRESSED = 16;

    const CONDITION_TYPE_DRULE = 18;

    const CONDITION_TYPE_DCHECK = 19;

    const CONDITION_TYPE_PROXY = 20;

    const CONDITION_TYPE_DOBJECT = 21;

    const CONDITION_TYPE_HOST_NAME = 22;

    const CONDITION_TYPE_EVENT_TYPE = 23;

    const CONDITION_TYPE_HOST_METADATA = 24;

    const CONDITION_TYPE_EVENT_TAG = 25;

    const CONDITION_TYPE_EVENT_TAG_VALUE = 26;

    const CONDITION_OPERATOR_EQUAL = 0;

    const CONDITION_OPERATOR_NOT_EQUAL = 1;

    const CONDITION_OPERATOR_LIKE = 2;

    const CONDITION_OPERATOR_NOT_LIKE = 3;

    const CONDITION_OPERATOR_IN = 4;

    const CONDITION_OPERATOR_MORE_EQUAL = 5;

    const CONDITION_OPERATOR_LESS_EQUAL = 6;

    const CONDITION_OPERATOR_NOT_IN = 7;

    const CONDITION_OPERATOR_REGEXP = 8;

    const CONDITION_OPERATOR_NOT_REGEXP = 9;

    const CONDITION_OPERATOR_YES = 10;

    const CONDITION_OPERATOR_NO = 11;

    const ZBX_CORRELATION_ENABLED = 0;

    const ZBX_CORRELATION_DISABLED = 1;

    const ZBX_CORR_CONDITION_OLD_EVENT_TAG = 0;

    const ZBX_CORR_CONDITION_NEW_EVENT_TAG = 1;

    const ZBX_CORR_CONDITION_NEW_EVENT_HOSTGROUP = 2;

    const ZBX_CORR_CONDITION_EVENT_TAG_PAIR = 3;

    const ZBX_CORR_CONDITION_OLD_EVENT_TAG_VALUE = 4;

    const ZBX_CORR_CONDITION_NEW_EVENT_TAG_VALUE = 5;

    const ZBX_CORR_OPERATION_CLOSE_OLD = 0;

    const ZBX_CORR_OPERATION_CLOSE_NEW = 1;

    const EVENT_TYPE_ITEM_NOTSUPPORTED = 0;

    const EVENT_TYPE_LLDRULE_NOTSUPPORTED = 2;

    const EVENT_TYPE_TRIGGER_UNKNOWN = 4;

    const HOST_STATUS_MONITORED = 0;

    const HOST_STATUS_NOT_MONITORED = 1;

    const HOST_STATUS_TEMPLATE = 3;

    const HOST_STATUS_PROXY_ACTIVE = 5;

    const HOST_STATUS_PROXY_PASSIVE = 6;

    const HOST_ENCRYPTION_NONE = 1;

    const HOST_ENCRYPTION_PSK = 2;

    const HOST_ENCRYPTION_CERTIFICATE = 4;

    const HOST_COMPRESSION_ON = 1;

    const PSK_MIN_LEN = 32;

    const HOST_MAINTENANCE_STATUS_OFF = 0;

    const HOST_MAINTENANCE_STATUS_ON = 1;

    const INTERFACE_SECONDARY = 0;

    const INTERFACE_PRIMARY = 1;

    const INTERFACE_USE_DNS = 0;

    const INTERFACE_USE_IP = 1;

    const INTERFACE_TYPE_ANY = -1;

    const INTERFACE_TYPE_UNKNOWN = 0;

    const INTERFACE_TYPE_AGENT = 1;

    const INTERFACE_TYPE_SNMP = 2;

    const INTERFACE_TYPE_IPMI = 3;

    const INTERFACE_TYPE_JMX = 4;

    const SNMP_BULK_DISABLED = 0;

    const SNMP_BULK_ENABLED = 1;

    const MAINTENANCE_STATUS_ACTIVE = 0;

    const MAINTENANCE_STATUS_APPROACH = 1;

    const MAINTENANCE_STATUS_EXPIRED = 2;

    const HOST_AVAILABLE_UNKNOWN = 0;

    const HOST_AVAILABLE_TRUE = 1;

    const HOST_AVAILABLE_FALSE = 2;

    const MAINTENANCE_TAG_EVAL_TYPE_AND_OR = 0;

    const MAINTENANCE_TAG_EVAL_TYPE_OR = 2;

    const MAINTENANCE_TAG_OPERATOR_EQUAL = 0;

    const MAINTENANCE_TAG_OPERATOR_LIKE = 2;

    const MAINTENANCE_TYPE_NORMAL = 0;

    const MAINTENANCE_TYPE_NODATA = 1;

    const TIMEPERIOD_TYPE_ONETIME = 0;

    const TIMEPERIOD_TYPE_HOURLY = 1;

    const TIMEPERIOD_TYPE_DAILY = 2;

    const TIMEPERIOD_TYPE_WEEKLY = 3;

    const TIMEPERIOD_TYPE_MONTHLY = 4;

    const TIMEPERIOD_TYPE_YEARLY = 5;

    const REPORT_PERIOD_TODAY = 0;

    const REPORT_PERIOD_YESTERDAY = 1;

    const REPORT_PERIOD_CURRENT_WEEK = 2;

    const REPORT_PERIOD_CURRENT_MONTH = 3;

    const REPORT_PERIOD_CURRENT_YEAR = 4;

    const REPORT_PERIOD_LAST_WEEK = 5;

    const REPORT_PERIOD_LAST_MONTH = 6;

    const REPORT_PERIOD_LAST_YEAR = 7;

    const SYSMAP_LABEL_ADVANCED_OFF = 0;

    const SYSMAP_LABEL_ADVANCED_ON = 1;

    const SYSMAP_PROBLEMS_NUMBER = 0;

    const SYSMAP_SINGLE_PROBLEM = 1;

    const SYSMAP_PROBLEMS_NUMBER_CRITICAL = 2;

    const MAP_LABEL_TYPE_LABEL = 0;

    const MAP_LABEL_TYPE_IP = 1;

    const MAP_LABEL_TYPE_NAME = 2;

    const MAP_LABEL_TYPE_STATUS = 3;

    const MAP_LABEL_TYPE_NOTHING = 4;

    const MAP_LABEL_TYPE_CUSTOM = 5;

    const MAP_LABEL_LOC_DEFAULT = -1;

    const MAP_LABEL_LOC_BOTTOM = 0;

    const MAP_LABEL_LOC_LEFT = 1;

    const MAP_LABEL_LOC_RIGHT = 2;

    const MAP_LABEL_LOC_TOP = 3;

    const SYSMAP_ELEMENT_TYPE_HOST = 0;

    const SYSMAP_ELEMENT_TYPE_MAP = 1;

    const SYSMAP_ELEMENT_TYPE_TRIGGER = 2;

    const SYSMAP_ELEMENT_TYPE_HOST_GROUP = 3;

    const SYSMAP_ELEMENT_TYPE_IMAGE = 4;

    const SYSMAP_ELEMENT_SUBTYPE_HOST_GROUP = 0;

    const SYSMAP_ELEMENT_SUBTYPE_HOST_GROUP_ELEMENTS = 1;

    const SYSMAP_ELEMENT_AREA_TYPE_FIT = 0;

    const SYSMAP_ELEMENT_AREA_TYPE_CUSTOM = 1;

    const SYSMAP_ELEMENT_AREA_VIEWTYPE_GRID = 0;

    const SYSMAP_ELEMENT_ICON_ON = 0;

    const SYSMAP_ELEMENT_ICON_OFF = 1;

    const SYSMAP_ELEMENT_ICON_MAINTENANCE = 3;

    const SYSMAP_ELEMENT_ICON_DISABLED = 4;

    const SYSMAP_SHAPE_TYPE_RECTANGLE = 0;

    const SYSMAP_SHAPE_TYPE_ELLIPSE = 1;

    const SYSMAP_SHAPE_TYPE_LINE = 2;

    const SYSMAP_SHAPE_BORDER_TYPE_NONE = 0;

    const SYSMAP_SHAPE_BORDER_TYPE_SOLID = 1;

    const SYSMAP_SHAPE_BORDER_TYPE_DOTTED = 2;

    const SYSMAP_SHAPE_BORDER_TYPE_DASHED = 3;

    const SYSMAP_SHAPE_LABEL_HALIGN_CENTER = 0;

    const SYSMAP_SHAPE_LABEL_HALIGN_LEFT = 1;

    const SYSMAP_SHAPE_LABEL_HALIGN_RIGHT = 2;

    const SYSMAP_SHAPE_LABEL_VALIGN_MIDDLE = 0;

    const SYSMAP_SHAPE_LABEL_VALIGN_TOP = 1;

    const SYSMAP_SHAPE_LABEL_VALIGN_BOTTOM = 2;

    const SYSMAP_HIGHLIGHT_OFF = 0;

    const SYSMAP_HIGHLIGHT_ON = 1;

    const SYSMAP_GRID_SHOW_ON = 1;

    const SYSMAP_GRID_SHOW_OFF = 0;

    const SYSMAP_EXPAND_MACROS_OFF = 0;

    const SYSMAP_EXPAND_MACROS_ON = 1;

    const SYSMAP_GRID_ALIGN_ON = 1;

    const SYSMAP_GRID_ALIGN_OFF = 0;

    const PUBLIC_SHARING = 0;

    const PRIVATE_SHARING = 1;

    const ZBX_ITEM_DELAY_DEFAULT = '1m';

    const ZBX_ITEM_FLEXIBLE_DELAY_DEFAULT = '50s';

    const ZBX_ITEM_SCHEDULING_DEFAULT = 'wd1-5h9-18';

    const ITEM_TYPE_ZABBIX = 0;

    const ITEM_TYPE_SNMPV1 = 1;

    const ITEM_TYPE_TRAPPER = 2;

    const ITEM_TYPE_SIMPLE = 3;

    const ITEM_TYPE_SNMPV2C = 4;

    const ITEM_TYPE_INTERNAL = 5;

    const ITEM_TYPE_SNMPV3 = 6;

    const ITEM_TYPE_ZABBIX_ACTIVE = 7;

    const ITEM_TYPE_AGGREGATE = 8;

    const ITEM_TYPE_HTTPTEST = 9;

    const ITEM_TYPE_EXTERNAL = 10;

    const ITEM_TYPE_DB_MONITOR = 11;

    const ITEM_TYPE_IPMI = 12;

    const ITEM_TYPE_SSH = 13;

    const ITEM_TYPE_TELNET = 14;

    const ITEM_TYPE_CALCULATED = 15;

    const ITEM_TYPE_JMX = 16;

    const ITEM_TYPE_SNMPTRAP = 17;

    const ITEM_TYPE_DEPENDENT = 18;

    const ITEM_TYPE_HTTPAGENT = 19;

    const ZBX_DEPENDENT_ITEM_MAX_LEVELS = 3;

    const ZBX_DEPENDENT_ITEM_MAX_COUNT = 29999;

    const ITEM_VALUE_TYPE_FLOAT = 0;

    const ITEM_VALUE_TYPE_STR = 1;

    const ITEM_VALUE_TYPE_LOG = 2;

    const ITEM_VALUE_TYPE_UINT64 = 3;

    const ITEM_VALUE_TYPE_TEXT = 4;

    const ITEM_DATA_TYPE_DECIMAL = 0;

    const ITEM_DATA_TYPE_OCTAL = 1;

    const ITEM_DATA_TYPE_HEXADECIMAL = 2;

    const ITEM_DATA_TYPE_BOOLEAN = 3;

    const ZBX_DEFAULT_KEY_DB_MONITOR = 'db.odbc.select[<unique short description>,dsn]';

    const ZBX_DEFAULT_KEY_DB_MONITOR_DISCOVERY = 'db.odbc.discovery[<unique short description>,dsn]';

    const ZBX_DEFAULT_KEY_SSH = 'ssh.run[<unique short description>,<ip>,<port>,<encoding>]';

    const ZBX_DEFAULT_KEY_TELNET = 'telnet.run[<unique short description>,<ip>,<port>,<encoding>]';

    const ZBX_DEFAULT_JMX_ENDPOINT = 'service:jmx:rmi:///jndi/rmi://{HOST.CONN}:{HOST.PORT}/jmxrmi';

    const SYSMAP_ELEMENT_USE_ICONMAP_ON = 1;

    const SYSMAP_ELEMENT_USE_ICONMAP_OFF = 0;

    const ZBX_ICON_PREVIEW_HEIGHT = 24;

    const ZBX_ICON_PREVIEW_WIDTH = 24;

    const ITEM_STATUS_ACTIVE = 0;

    const ITEM_STATUS_DISABLED = 1;

    const ITEM_STATUS_NOTSUPPORTED = 3;

    const ITEM_STATE_NORMAL = 0;

    const ITEM_STATE_NOTSUPPORTED = 1;

    const ITEM_SNMPV3_SECURITYLEVEL_NOAUTHNOPRIV = 0;

    const ITEM_SNMPV3_SECURITYLEVEL_AUTHNOPRIV = 1;

    const ITEM_SNMPV3_SECURITYLEVEL_AUTHPRIV = 2;

    const ITEM_AUTHTYPE_PASSWORD = 0;

    const ITEM_AUTHTYPE_PUBLICKEY = 1;

    const ITEM_AUTHPROTOCOL_MD5 = 0;

    const ITEM_AUTHPROTOCOL_SHA = 1;

    const ITEM_PRIVPROTOCOL_DES = 0;

    const ITEM_PRIVPROTOCOL_AES = 1;

    const ITEM_LOGTYPE_INFORMATION = 1;

    const ITEM_LOGTYPE_WARNING = 2;

    const ITEM_LOGTYPE_ERROR = 4;

    const ITEM_LOGTYPE_FAILURE_AUDIT = 7;

    const ITEM_LOGTYPE_SUCCESS_AUDIT = 8;

    const ITEM_LOGTYPE_CRITICAL = 9;

    const ITEM_LOGTYPE_VERBOSE = 10;

    const ITEM_DELAY_FLEXIBLE = 0;

    const ITEM_DELAY_SCHEDULING = 1;

    const ZBX_PREPROC_MULTIPLIER = 1;

    const ZBX_PREPROC_RTRIM = 2;

    const ZBX_PREPROC_LTRIM = 3;

    const ZBX_PREPROC_TRIM = 4;

    const ZBX_PREPROC_REGSUB = 5;

    const ZBX_PREPROC_BOOL2DEC = 6;

    const ZBX_PREPROC_OCT2DEC = 7;

    const ZBX_PREPROC_HEX2DEC = 8;

    const ZBX_PREPROC_DELTA_VALUE = 9;

    const ZBX_PREPROC_DELTA_SPEED = 10;

    const ZBX_PREPROC_XPATH = 11;

    const ZBX_PREPROC_JSONPATH = 12;

    const ZBX_PREPROC_VALIDATE_RANGE = 13;

    const ZBX_PREPROC_VALIDATE_REGEX = 14;

    const ZBX_PREPROC_VALIDATE_NOT_REGEX = 15;

    const ZBX_PREPROC_ERROR_FIELD_JSON = 16;

    const ZBX_PREPROC_ERROR_FIELD_XML = 17;

    const ZBX_PREPROC_ERROR_FIELD_REGEX = 18;

    const ZBX_PREPROC_THROTTLE_VALUE = 19;

    const ZBX_PREPROC_THROTTLE_TIMED_VALUE = 20;

    const ZBX_PREPROC_SCRIPT = 21;

    const ZBX_PREPROC_PROMETHEUS_PATTERN = 22;

    const ZBX_PREPROC_PROMETHEUS_TO_JSON = 23;

    const ZBX_PREPROC_CSV_TO_JSON = 24;

    const ZBX_PREPROC_FAIL_DEFAULT = 0;

    const ZBX_PREPROC_FAIL_DISCARD_VALUE = 1;

    const ZBX_PREPROC_FAIL_SET_VALUE = 2;

    const ZBX_PREPROC_FAIL_SET_ERROR = 3;

    const ZBX_PREPROC_CSV_NO_HEADER = 0;

    const ZBX_PREPROC_CSV_HEADER = 1;

    const GRAPH_ITEM_DRAWTYPE_LINE = 0;

    const GRAPH_ITEM_DRAWTYPE_FILLED_REGION = 1;

    const GRAPH_ITEM_DRAWTYPE_BOLD_LINE = 2;

    const GRAPH_ITEM_DRAWTYPE_DOT = 3;

    const GRAPH_ITEM_DRAWTYPE_DASHED_LINE = 4;

    const GRAPH_ITEM_DRAWTYPE_GRADIENT_LINE = 5;

    const GRAPH_ITEM_DRAWTYPE_BOLD_DOT = 6;

    const MAP_LINK_DRAWTYPE_LINE = 0;

    const MAP_LINK_DRAWTYPE_BOLD_LINE = 2;

    const MAP_LINK_DRAWTYPE_DOT = 3;

    const MAP_LINK_DRAWTYPE_DASHED_LINE = 4;

    const SERVICE_ALGORITHM_NONE = 0;

    const SERVICE_ALGORITHM_MAX = 1;

    const SERVICE_ALGORITHM_MIN = 2;

    const SERVICE_SLA = '99.9000';

    const SERVICE_SHOW_SLA_OFF = 0;

    const SERVICE_SHOW_SLA_ON = 1;

    const SERVICE_STATUS_OK = 0;

    const TRIGGER_MULT_EVENT_DISABLED = 0;

    const TRIGGER_MULT_EVENT_ENABLED = 1;

    const ZBX_TRIGGER_CORRELATION_NONE = 0;

    const ZBX_TRIGGER_CORRELATION_TAG = 1;

    const ZBX_TRIGGER_MANUAL_CLOSE_NOT_ALLOWED = 0;

    const ZBX_TRIGGER_MANUAL_CLOSE_ALLOWED = 1;

    const ZBX_RECOVERY_MODE_EXPRESSION = 0;

    const ZBX_RECOVERY_MODE_RECOVERY_EXPRESSION = 1;

    const ZBX_RECOVERY_MODE_NONE = 2;

    const TRIGGER_STATUS_ENABLED = 0;

    const TRIGGER_STATUS_DISABLED = 1;

    const TRIGGER_VALUE_FALSE = 0;

    const TRIGGER_VALUE_TRUE = 1;

    const TRIGGER_STATE_NORMAL = 0;

    const TRIGGER_STATE_UNKNOWN = 1;

    const TRIGGER_SEVERITY_NOT_CLASSIFIED = 0;

    const TRIGGER_SEVERITY_INFORMATION = 1;

    const TRIGGER_SEVERITY_WARNING = 2;

    const TRIGGER_SEVERITY_AVERAGE = 3;

    const TRIGGER_SEVERITY_HIGH = 4;

    const TRIGGER_SEVERITY_DISASTER = 5;

    const TRIGGER_SEVERITY_COUNT = 6;

    const EVENT_CUSTOM_COLOR_DISABLED = 0;

    const EVENT_CUSTOM_COLOR_ENABLED = 1;

    const ALERT_STATUS_NOT_SENT = 0;

    const ALERT_STATUS_SENT = 1;

    const ALERT_STATUS_FAILED = 2;

    const ALERT_STATUS_NEW = 3;

    const ALERT_TYPE_MESSAGE = 0;

    const ALERT_TYPE_COMMAND = 1;

    const MEDIA_STATUS_ACTIVE = 0;

    const MEDIA_STATUS_DISABLED = 1;

    const MEDIA_TYPE_STATUS_ACTIVE = 0;

    const MEDIA_TYPE_STATUS_DISABLED = 1;

    const ZBX_MEDIA_TYPE_TAGS_DISABLED = 0;

    const ZBX_MEDIA_TYPE_TAGS_ENABLED = 1;

    const ZBX_EVENT_MENU_HIDE = 0;

    const ZBX_EVENT_MENU_SHOW = 1;

    const MEDIA_TYPE_EMAIL = 0;

    const MEDIA_TYPE_EXEC = 1;

    const MEDIA_TYPE_SMS = 2;

    const MEDIA_TYPE_WEBHOOK = 4;

    const SMTP_CONNECTION_SECURITY_NONE = 0;

    const SMTP_CONNECTION_SECURITY_STARTTLS = 1;

    const SMTP_CONNECTION_SECURITY_SSL_TLS = 2;

    const SMTP_AUTHENTICATION_NONE = 0;

    const SMTP_AUTHENTICATION_NORMAL = 1;

    const SMTP_MESSAGE_FORMAT_PLAIN_TEXT = 0;

    const SMTP_MESSAGE_FORMAT_HTML = 1;

    const ACTION_DEFAULT_SUBJ_AUTOREG = 'Auto registration: {HOST.HOST}';

    const ACTION_DEFAULT_SUBJ_DISCOVERY = 'Discovery: {DISCOVERY.DEVICE.STATUS} {DISCOVERY.DEVICE.IPADDRESS}';

    const ACTION_DEFAULT_SUBJ_ACKNOWLEDGE = 'Updated problem: {EVENT.NAME}';

    const ACTION_DEFAULT_SUBJ_PROBLEM = 'Problem: {EVENT.NAME}';

    const ACTION_DEFAULT_SUBJ_RECOVERY = 'Resolved: {EVENT.NAME}';

    const ACTION_DEFAULT_MSG_AUTOREG = "Host name: {HOST.HOST}\nHost IP: {HOST.IP}\nAgent port: {HOST.PORT}";

    const ACTION_STATUS_ENABLED = 0;

    const ACTION_STATUS_DISABLED = 1;

    const ACTION_PAUSE_SUPPRESSED_FALSE = 0;

    const ACTION_PAUSE_SUPPRESSED_TRUE = 1;

    const OPERATION_TYPE_MESSAGE = 0;

    const OPERATION_TYPE_COMMAND = 1;

    const OPERATION_TYPE_HOST_ADD = 2;

    const OPERATION_TYPE_HOST_REMOVE = 3;

    const OPERATION_TYPE_GROUP_ADD = 4;

    const OPERATION_TYPE_GROUP_REMOVE = 5;

    const OPERATION_TYPE_TEMPLATE_ADD = 6;

    const OPERATION_TYPE_TEMPLATE_REMOVE = 7;

    const OPERATION_TYPE_HOST_ENABLE = 8;

    const OPERATION_TYPE_HOST_DISABLE = 9;

    const OPERATION_TYPE_HOST_INVENTORY = 10;

    const OPERATION_TYPE_RECOVERY_MESSAGE = 11;

    const OPERATION_TYPE_ACK_MESSAGE = 12;

    const ACTION_OPERATION = 0;

    const ACTION_RECOVERY_OPERATION = 1;

    const ACTION_ACKNOWLEDGE_OPERATION = 2;

    const CONDITION_EVAL_TYPE_AND_OR = 0;

    const CONDITION_EVAL_TYPE_AND = 1;

    const CONDITION_EVAL_TYPE_OR = 2;

    const CONDITION_EVAL_TYPE_EXPRESSION = 3;

    const SCREEN_RESOURCE_GRAPH = 0;

    const SCREEN_RESOURCE_SIMPLE_GRAPH = 1;

    const SCREEN_RESOURCE_MAP = 2;

    const SCREEN_RESOURCE_PLAIN_TEXT = 3;

    const SCREEN_RESOURCE_HOST_INFO = 4;

    const SCREEN_RESOURCE_TRIGGER_INFO = 5;

    const SCREEN_RESOURCE_SERVER_INFO = 6;

    const SCREEN_RESOURCE_CLOCK = 7;

    const SCREEN_RESOURCE_SCREEN = 8;

    const SCREEN_RESOURCE_TRIGGER_OVERVIEW = 9;

    const SCREEN_RESOURCE_DATA_OVERVIEW = 10;

    const SCREEN_RESOURCE_URL = 11;

    const SCREEN_RESOURCE_ACTIONS = 12;

    const SCREEN_RESOURCE_EVENTS = 13;

    const SCREEN_RESOURCE_HOSTGROUP_TRIGGERS = 14;

    const SCREEN_RESOURCE_SYSTEM_STATUS = 15;

    const SCREEN_RESOURCE_HOST_TRIGGERS = 16;

    const SCREEN_RESOURCE_HISTORY = 17;

    const SCREEN_RESOURCE_CHART = 18;

    const SCREEN_RESOURCE_LLD_SIMPLE_GRAPH = 19;

    const SCREEN_RESOURCE_LLD_GRAPH = 20;

    const SCREEN_RESOURCE_HTTPTEST_DETAILS = 21;

    const SCREEN_RESOURCE_DISCOVERY = 22;

    const SCREEN_RESOURCE_HTTPTEST = 23;

    const SCREEN_RESOURCE_PROBLEM = 24;

    const SCREEN_SORT_TRIGGERS_DATE_DESC = 0;

    const SCREEN_SORT_TRIGGERS_SEVERITY_DESC = 1;

    const SCREEN_SORT_TRIGGERS_HOST_NAME_ASC = 2;

    const SCREEN_SORT_TRIGGERS_TIME_ASC = 3;

    const SCREEN_SORT_TRIGGERS_TIME_DESC = 4;

    const SCREEN_SORT_TRIGGERS_TYPE_ASC = 5;

    const SCREEN_SORT_TRIGGERS_TYPE_DESC = 6;

    const SCREEN_SORT_TRIGGERS_STATUS_ASC = 7;

    const SCREEN_SORT_TRIGGERS_STATUS_DESC = 8;

    const SCREEN_SORT_TRIGGERS_RECIPIENT_ASC = 11;

    const SCREEN_SORT_TRIGGERS_RECIPIENT_DESC = 12;

    const SCREEN_SORT_TRIGGERS_SEVERITY_ASC = 13;

    const SCREEN_SORT_TRIGGERS_HOST_NAME_DESC = 14;

    const SCREEN_SORT_TRIGGERS_NAME_ASC = 15;

    const SCREEN_SORT_TRIGGERS_NAME_DESC = 16;

    const SCREEN_MODE_PREVIEW = 0;

    const SCREEN_MODE_EDIT = 1;

    const SCREEN_MODE_SLIDESHOW = 2;

    const SCREEN_MODE_JS = 3;

    const SCREEN_SIMPLE_ITEM = 0;

    const SCREEN_DYNAMIC_ITEM = 1;

    const SCREEN_REFRESH_RESPONSIVENESS = 10;

    const SCREEN_SURROGATE_MAX_COLUMNS_MIN = 1;

    const SCREEN_SURROGATE_MAX_COLUMNS_DEFAULT = 3;

    const SCREEN_SURROGATE_MAX_COLUMNS_MAX = 100;

    const SCREEN_MIN_SIZE = 1;

    const SCREEN_MAX_SIZE = 100;

    const ZBX_DEFAULT_WIDGET_LINES = 25;

    const ZBX_MIN_WIDGET_LINES = 1;

    const ZBX_MAX_WIDGET_LINES = 100;

    const DASHBOARD_MAX_COLUMNS = 24;

    const DASHBOARD_MAX_ROWS = 64;

    const DASHBOARD_WIDGET_MIN_ROWS = 2;

    const DASHBOARD_WIDGET_MAX_ROWS = 32;

    const HALIGN_DEFAULT = 0;

    const HALIGN_CENTER = 0;

    const HALIGN_LEFT = 1;

    const HALIGN_RIGHT = 2;

    const VALIGN_DEFAULT = 0;

    const VALIGN_MIDDLE = 0;

    const VALIGN_TOP = 1;

    const VALIGN_BOTTOM = 2;

    const STYLE_HORIZONTAL = 0;

    const STYLE_VERTICAL = 1;

    const STYLE_LEFT = 0;

    const STYLE_TOP = 1;

    const TIME_TYPE_LOCAL = 0;

    const TIME_TYPE_SERVER = 1;

    const TIME_TYPE_HOST = 2;

    const FILTER_TASK_SHOW = 0;

    const FILTER_TASK_HIDE = 1;

    const FILTER_TASK_MARK = 2;

    const FILTER_TASK_INVERT_MARK = 3;

    const MARK_COLOR_RED = 1;

    const MARK_COLOR_GREEN = 2;

    const MARK_COLOR_BLUE = 3;

    const PROFILE_TYPE_ID = 1;

    const PROFILE_TYPE_INT = 2;

    const PROFILE_TYPE_STR = 3;

    const CALC_FNC_MIN = 1;

    const CALC_FNC_AVG = 2;

    const CALC_FNC_MAX = 4;

    const CALC_FNC_ALL = 7;

    const CALC_FNC_LST = 9;

    const SERVICE_TIME_TYPE_UPTIME = 0;

    const SERVICE_TIME_TYPE_DOWNTIME = 1;

    const SERVICE_TIME_TYPE_ONETIME_DOWNTIME = 2;

    const ZBX_DISCOVERY_UNSPEC = 0;

    const ZBX_DISCOVERY_DNS = 1;

    const ZBX_DISCOVERY_IP = 2;

    const ZBX_DISCOVERY_VALUE = 3;

    const USER_TYPE_ZABBIX_USER = 1;

    const USER_TYPE_ZABBIX_ADMIN = 2;

    const USER_TYPE_SUPER_ADMIN = 3;

    const ZBX_NOT_INTERNAL_GROUP = 0;

    const ZBX_INTERNAL_GROUP = 1;

    const GROUP_STATUS_DISABLED = 1;

    const GROUP_STATUS_ENABLED = 0;

    const LINE_TYPE_NORMAL = 0;

    const LINE_TYPE_BOLD = 1;

    const GROUP_GUI_ACCESS_SYSTEM = 0;

    const GROUP_GUI_ACCESS_INTERNAL = 1;

    const GROUP_GUI_ACCESS_LDAP = 2;

    const GROUP_GUI_ACCESS_DISABLED = 3;

    const ACCESS_DENY_OBJECT = 0;

    const ACCESS_DENY_PAGE = 1;

    const GROUP_DEBUG_MODE_DISABLED = 0;

    const GROUP_DEBUG_MODE_ENABLED = 1;

    const PERM_READ_WRITE = 3;

    const PERM_READ = 2;

    const PERM_DENY = 0;

    const PERM_NONE = -1;

    const PARAM_TYPE_TIME = 0;

    const PARAM_TYPE_COUNTS = 1;

    const ZBX_DEFAULT_AGENT = 'Zabbix';

    const ZBX_AGENT_OTHER = -1;

    const HTTPTEST_AUTH_NONE = 0;

    const HTTPTEST_AUTH_BASIC = 1;

    const HTTPTEST_AUTH_NTLM = 2;

    const HTTPTEST_AUTH_KERBEROS = 3;

    const HTTPTEST_STATUS_ACTIVE = 0;

    const HTTPTEST_STATUS_DISABLED = 1;

    const ZBX_HTTPFIELD_HEADER = 0;

    const ZBX_HTTPFIELD_VARIABLE = 1;

    const ZBX_HTTPFIELD_POST_FIELD = 2;

    const ZBX_HTTPFIELD_QUERY_FIELD = 3;

    const ZBX_POSTTYPE_RAW = 0;

    const ZBX_POSTTYPE_FORM = 1;

    const ZBX_POSTTYPE_JSON = 2;

    const ZBX_POSTTYPE_XML = 3;

    const HTTPCHECK_STORE_RAW = 0;

    const HTTPCHECK_STORE_JSON = 1;

    const HTTPCHECK_ALLOW_TRAPS_OFF = 0;

    const HTTPCHECK_ALLOW_TRAPS_ON = 1;

    const HTTPCHECK_REQUEST_GET = 0;

    const HTTPCHECK_REQUEST_POST = 1;

    const HTTPCHECK_REQUEST_PUT = 2;

    const HTTPCHECK_REQUEST_HEAD = 3;

    const HTTPSTEP_ITEM_TYPE_RSPCODE = 0;

    const HTTPSTEP_ITEM_TYPE_TIME = 1;

    const HTTPSTEP_ITEM_TYPE_IN = 2;

    const HTTPSTEP_ITEM_TYPE_LASTSTEP = 3;

    const HTTPSTEP_ITEM_TYPE_LASTERROR = 4;

    const HTTPTEST_STEP_RETRIEVE_MODE_CONTENT = 0;

    const HTTPTEST_STEP_RETRIEVE_MODE_HEADERS = 1;

    const HTTPTEST_STEP_RETRIEVE_MODE_BOTH = 2;

    const HTTPTEST_STEP_FOLLOW_REDIRECTS_OFF = 0;

    const HTTPTEST_STEP_FOLLOW_REDIRECTS_ON = 1;

    const HTTPTEST_VERIFY_PEER_OFF = 0;

    const HTTPTEST_VERIFY_PEER_ON = 1;

    const HTTPTEST_VERIFY_HOST_OFF = 0;

    const HTTPTEST_VERIFY_HOST_ON = 1;

    const EVENT_NOT_ACKNOWLEDGED = '0';

    const EVENT_ACKNOWLEDGED = '1';

    const ZBX_ACKNOWLEDGE_SELECTED = 0;

    const ZBX_ACKNOWLEDGE_PROBLEM = 1;

    const ZBX_PROBLEM_SUPPRESSED_FALSE = 0;

    const ZBX_PROBLEM_SUPPRESSED_TRUE = 1;

    const ZBX_PROBLEM_UPDATE_NONE = 0x00;

    const ZBX_PROBLEM_UPDATE_CLOSE = 0x01;

    const ZBX_PROBLEM_UPDATE_ACKNOWLEDGE = 0x02;

    const ZBX_PROBLEM_UPDATE_MESSAGE = 0x04;

    const ZBX_PROBLEM_UPDATE_SEVERITY = 0x08;

    const ZBX_EVENT_HISTORY_PROBLEM_EVENT = 0;

    const ZBX_EVENT_HISTORY_RECOVERY_EVENT = 1;

    const ZBX_EVENT_HISTORY_MANUAL_UPDATE = 2;

    const ZBX_EVENT_HISTORY_ALERT = 3;

    const ZBX_TM_TASK_CLOSE_PROBLEM = 1;

    const ZBX_TM_TASK_ACKNOWLEDGE = 4;

    const ZBX_TM_TASK_CHECK_NOW = 6;

    const ZBX_TM_STATUS_NEW = 1;

    const ZBX_TM_STATUS_INPROGRESS = 2;

    const EVENT_SOURCE_TRIGGERS = 0;

    const EVENT_SOURCE_DISCOVERY = 1;

    const EVENT_SOURCE_AUTO_REGISTRATION = 2;

    const EVENT_SOURCE_INTERNAL = 3;

    const EVENT_OBJECT_TRIGGER = 0;

    const EVENT_OBJECT_DHOST = 1;

    const EVENT_OBJECT_DSERVICE = 2;

    const EVENT_OBJECT_AUTOREGHOST = 3;

    const EVENT_OBJECT_ITEM = 4;

    const EVENT_OBJECT_LLDRULE = 5;

    const TAG_EVAL_TYPE_AND_OR = 0;

    const TAG_EVAL_TYPE_OR = 2;

    const TAG_OPERATOR_LIKE = 0;

    const TAG_OPERATOR_EQUAL = 1;

    const GRAPH_AGGREGATE_DEFAULT_INTERVAL = '1h';

    const GRAPH_AGGREGATE_NONE = 0;

    const GRAPH_AGGREGATE_MIN = 1;

    const GRAPH_AGGREGATE_MAX = 2;

    const GRAPH_AGGREGATE_AVG = 3;

    const GRAPH_AGGREGATE_COUNT = 4;

    const GRAPH_AGGREGATE_SUM = 5;

    const GRAPH_AGGREGATE_FIRST = 6;

    const GRAPH_AGGREGATE_LAST = 7;

    const GRAPH_AGGREGATE_BY_ITEM = 0;

    const GRAPH_AGGREGATE_BY_DATASET = 1;

    const GRAPH_YAXIS_TYPE_CALCULATED = 0;

    const GRAPH_YAXIS_TYPE_FIXED = 1;

    const GRAPH_YAXIS_TYPE_ITEM_VALUE = 2;

    const GRAPH_YAXIS_SIDE_LEFT = 0;

    const GRAPH_YAXIS_SIDE_RIGHT = 1;

    const GRAPH_YAXIS_SIDE_BOTTOM = 2;

    const GRAPH_ITEM_SIMPLE = 0;

    const GRAPH_ITEM_SUM = 2;

    const GRAPH_TYPE_NORMAL = 0;

    const GRAPH_TYPE_STACKED = 1;

    const GRAPH_TYPE_PIE = 2;

    const GRAPH_TYPE_EXPLODED = 3;

    const GRAPH_TYPE_3D = 4;

    const GRAPH_TYPE_3D_EXPLODED = 5;

    const GRAPH_TYPE_BAR = 6;

    const GRAPH_TYPE_COLUMN = 7;

    const GRAPH_TYPE_BAR_STACKED = 8;

    const GRAPH_TYPE_COLUMN_STACKED = 9;

    const SVG_GRAPH_TYPE_LINE = 0;

    const SVG_GRAPH_TYPE_POINTS = 1;

    const SVG_GRAPH_TYPE_STAIRCASE = 2;

    const SVG_GRAPH_TYPE_BAR = 3;

    const SVG_GRAPH_MISSING_DATA_NONE = 0;

    const SVG_GRAPH_MISSING_DATA_CONNECTED = 1;

    const SVG_GRAPH_MISSING_DATA_TREAT_AS_ZERO = 2;

    const SVG_GRAPH_DATA_SOURCE_AUTO = 0;

    const SVG_GRAPH_DATA_SOURCE_HISTORY = 1;

    const SVG_GRAPH_DATA_SOURCE_TRENDS = 2;

    const SVG_GRAPH_CUSTOM_TIME = 1;

    const SVG_GRAPH_LEGEND_TYPE_NONE = 0;

    const SVG_GRAPH_LEGEND_TYPE_SHORT = 1;

    const SVG_GRAPH_LEGEND_LINES_MIN = 1;

    const SVG_GRAPH_LEGEND_LINES_MAX = 5;

    const SVG_GRAPH_PROBLEMS_SHOW = 1;

    const SVG_GRAPH_SELECTED_ITEM_PROBLEMS = 1;

    const SVG_GRAPH_AXIS_SHOW = 1;

    const SVG_GRAPH_AXIS_UNITS_AUTO = 0;

    const SVG_GRAPH_AXIS_UNITS_STATIC = 1;

    const SVG_GRAPH_MAX_NUMBER_OF_METRICS = 50;

    const SVG_GRAPH_DEFAULT_WIDTH = 1;

    const SVG_GRAPH_DEFAULT_POINTSIZE = 3;

    const SVG_GRAPH_DEFAULT_TRANSPARENCY = 5;

    const SVG_GRAPH_DEFAULT_FILL = 3;

    const BR_DISTRIBUTION_MULTIPLE_PERIODS = 1;

    const BR_DISTRIBUTION_MULTIPLE_ITEMS = 2;

    const BR_COMPARE_VALUE_MULTIPLE_PERIODS = 3;

    const GRAPH_3D_ANGLE = 70;

    const GRAPH_STACKED_ALFA = 15;

    const GRAPH_ZERO_LINE_COLOR_LEFT = 'AAAAAA';

    const GRAPH_ZERO_LINE_COLOR_RIGHT = '888888';

    const GRAPH_TRIGGER_LINE_OPPOSITE_COLOR = '000000';

    const ZBX_MAX_TREND_DIFF = 3600;

    const ZBX_GRAPH_MAX_SKIP_CELL = 16;

    const ZBX_GRAPH_MAX_SKIP_DELAY = 4;

    const DOBJECT_STATUS_UP = 0;

    const DOBJECT_STATUS_DOWN = 1;

    const DOBJECT_STATUS_DISCOVER = 2;

    const DOBJECT_STATUS_LOST = 3;

    const DRULE_STATUS_ACTIVE = 0;

    const DRULE_STATUS_DISABLED = 1;

    const DSVC_STATUS_ACTIVE = 0;

    const DSVC_STATUS_DISABLED = 1;

    const SVC_SSH = 0;

    const SVC_LDAP = 1;

    const SVC_SMTP = 2;

    const SVC_FTP = 3;

    const SVC_HTTP = 4;

    const SVC_POP = 5;

    const SVC_NNTP = 6;

    const SVC_IMAP = 7;

    const SVC_TCP = 8;

    const SVC_AGENT = 9;

    const SVC_SNMPv1 = 10;

    const SVC_SNMPv2c = 11;

    const SVC_ICMPPING = 12;

    const SVC_SNMPv3 = 13;

    const SVC_HTTPS = 14;

    const SVC_TELNET = 15;

    const DHOST_STATUS_ACTIVE = 0;

    const DHOST_STATUS_DISABLED = 1;

    const IM_FORCED = 0;

    const IM_ESTABLISHED = 1;

    const IM_TREE = 2;

    const TRIGGER_EXPRESSION = 0;

    const TRIGGER_RECOVERY_EXPRESSION = 1;

    const EXPRESSION_TYPE_INCLUDED = 0;

    const EXPRESSION_TYPE_ANY_INCLUDED = 1;

    const EXPRESSION_TYPE_NOT_INCLUDED = 2;

    const EXPRESSION_TYPE_TRUE = 3;

    const EXPRESSION_TYPE_FALSE = 4;

    const HOST_INVENTORY_DISABLED = -1;

    const HOST_INVENTORY_MANUAL = 0;

    const HOST_INVENTORY_AUTOMATIC = 1;

    const INVENTORY_URL_MACRO_NONE = -1;

    const INVENTORY_URL_MACRO_HOST = 0;

    const INVENTORY_URL_MACRO_TRIGGER = 1;

    const EXPRESSION_HOST_UNKNOWN = '#ERROR_HOST#';

    const EXPRESSION_HOST_ITEM_UNKNOWN = '#ERROR_ITEM#';

    const EXPRESSION_NOT_A_MACRO_ERROR = '#ERROR_MACRO#';

    const EXPRESSION_FUNCTION_UNKNOWN = '#ERROR_FUNCTION#';

    const EXPRESSION_UNSUPPORTED_VALUE_TYPE = '#ERROR_VALUE_TYPE#';

    const SPACE = '&nbsp;';

    const NAME_DELIMITER = ': ';

    const UNKNOWN_VALUE = '';

    const ZBX_EOL_LF = 0;

    const ZBX_EOL_CRLF = 1;

    const ZBX_BYTE_SUFFIXES = 'KMGT';

    const ZBX_TIME_SUFFIXES = 'smhdw';

    const ZBX_TIME_SUFFIXES_WITH_YEAR = 'smhdwMy';

    const ZBX_PREG_PRINT = '^\x00-\x1F';

    const ZBX_PREG_MACRO_NAME = '([A-Z0-9\._]+)';

    const ZBX_PREG_MACRO_NAME_LLD = '([A-Z0-9\._]+)';

    const ZBX_PREG_INTERNAL_NAMES = '([0-9a-zA-Z_\. \-]+)';

    const ZBX_PREG_NUMBER = '([\-+]?[0-9]+[.]?[0-9]*['.self::ZBX_BYTE_SUFFIXES.self::ZBX_TIME_SUFFIXES.']?)';

    const ZBX_PREG_INT = '([\-+]?[0-9]+['.self::ZBX_BYTE_SUFFIXES.self::ZBX_TIME_SUFFIXES.']?)';

    const ZBX_PREG_DEF_FONT_STRING = '/^[0-9\.:% ]+$/';

    const ZBX_PREG_DNS_FORMAT = '([0-9a-zA-Z_\.\-$]|\{\$?'.self::ZBX_PREG_MACRO_NAME.'\})*';

    const ZBX_PREG_HOST_FORMAT = self::ZBX_PREG_INTERNAL_NAMES;

    const ZBX_PREG_MACRO_NAME_FORMAT = '(\{[A-Z\.]+\})';

    const ZBX_PREG_EXPRESSION_LLD_MACROS = '(\{\#'.self::ZBX_PREG_MACRO_NAME_LLD.'\})';

    const ZBX_USER_ONLINE_TIME = 600;

    const ZBX_GUEST_USER = 'guest';

    const IPMI_AUTHTYPE_DEFAULT = -1;

    const IPMI_AUTHTYPE_NONE = 0;

    const IPMI_AUTHTYPE_MD2 = 1;

    const IPMI_AUTHTYPE_MD5 = 2;

    const IPMI_AUTHTYPE_STRAIGHT = 4;

    const IPMI_AUTHTYPE_OEM = 5;

    const IPMI_AUTHTYPE_RMCP_PLUS = 6;

    const IPMI_PRIVILEGE_CALLBACK = 1;

    const IPMI_PRIVILEGE_USER = 2;

    const IPMI_PRIVILEGE_OPERATOR = 3;

    const IPMI_PRIVILEGE_ADMIN = 4;

    const IPMI_PRIVILEGE_OEM = 5;

    const ZBX_HAVE_IPV6 = true;

    const ZBX_DISCOVERER_IPRANGE_LIMIT = 65536;

    const ZBX_SOCKET_TIMEOUT = 3;

    const ZBX_SOCKET_BYTES_LIMIT = self::ZBX_MEBIBYTE * 16;

    const SERVER_CHECK_INTERVAL = 10;

    const DATE_TIME_FORMAT_SECONDS_XML = 'Y-m-d\TH:i:s\Z';

    const XML_TAG_MACRO = 'macro';

    const XML_TAG_HOST = 'host';

    const XML_TAG_HOSTINVENTORY = 'host_inventory';

    const XML_TAG_ITEM = 'item';

    const XML_TAG_TRIGGER = 'trigger';

    const XML_TAG_GRAPH = 'graph';

    const XML_TAG_GRAPH_ELEMENT = 'graph_element';

    const XML_TAG_DEPENDENCY = 'dependency';

    const ZBX_DEFAULT_IMPORT_HOST_GROUP = 'Imported hosts';

    const LIBXML_IMPORT_FLAGS = LIBXML_NONET;

    const XML_STRING = 0x01;

    const XML_ARRAY = 0x02;

    const XML_INDEXED_ARRAY = 0x04;

    const XML_REQUIRED = 0x08;

    const API_MULTIPLE = 0;

    const API_STRING_UTF8 = 1;

    const API_INT32 = 2;

    const API_ID = 3;

    const API_BOOLEAN = 4;

    const API_FLAG = 5;

    const API_FLOAT = 6;

    const API_UINT64 = 7;

    const API_OBJECT = 8;

    const API_IDS = 9;

    const API_OBJECTS = 10;

    const API_STRINGS_UTF8 = 11;

    const API_INTS32 = 12;

    const API_FLOATS = 13;

    const API_UINTS64 = 14;

    const API_HG_NAME = 15;

    const API_SCRIPT_NAME = 16;

    const API_USER_MACRO = 17;

    const API_TIME_PERIOD = 18;

    const API_REGEX = 19;

    const API_HTTP_POST = 20;

    const API_VARIABLE_NAME = 21;

    const API_OUTPUT = 22;

    const API_TIME_UNIT = 23;

    const API_URL = 24;

    const API_H_NAME = 25;

    const API_RANGE_TIME = 26;

    const API_COLOR = 27;

    const API_NUMERIC = 28;

    const API_LLD_MACRO = 29;

    const API_PSK = 30;

    const API_REQUIRED = 0x0001;

    const API_NOT_EMPTY = 0x0002;

    const API_ALLOW_NULL = 0x0004;

    const API_NORMALIZE = 0x0008;

    const API_DEPRECATED = 0x0010;

    const API_ALLOW_USER_MACRO = 0x0020;

    const API_ALLOW_COUNT = 0x0040;

    const API_ALLOW_LLD_MACRO = 0x0080;

    const API_REQUIRED_LLD_MACRO = 0x0100;

    const API_TIME_UNIT_WITH_YEAR = 0x0200;

    const API_ALLOW_EVENT_TAGS_MACRO = 0x0400;

    const ZBX_API_ERROR_INTERNAL = 111;

    const ZBX_API_ERROR_PARAMETERS = 100;

    const ZBX_API_ERROR_PERMISSIONS = 120;

    const ZBX_API_ERROR_NO_AUTH = 200;

    const ZBX_API_ERROR_NO_METHOD = 300;

    const API_OUTPUT_EXTEND = 'extend';

    const API_OUTPUT_COUNT = 'count';

    const SEC_PER_MIN = 60;

    const SEC_PER_HOUR = 3600;

    const SEC_PER_DAY = 86400;

    const SEC_PER_WEEK = 604800;

    const SEC_PER_MONTH = 2592000;

    const SEC_PER_YEAR = 31536000;

    const ZBX_JAN_2038 = 2145916800;

    const DAY_IN_YEAR = 365;

    const ZBX_MIN_PORT_NUMBER = 0;

    const ZBX_MAX_PORT_NUMBER = 65535;

    const ZBX_LAYOUT_NORMAL = 0;

    const ZBX_LAYOUT_FULLSCREEN = 1;

    const ZBX_LAYOUT_KIOSKMODE = 2;

    const ZBX_LAYOUT_MODE = 'layout-mode';

    const ZBX_TEXTAREA_HTTP_PAIR_NAME_WIDTH = 218;

    const ZBX_TEXTAREA_HTTP_PAIR_VALUE_WIDTH = 218;

    const ZBX_TEXTAREA_MACRO_WIDTH = 250;

    const ZBX_TEXTAREA_MACRO_VALUE_WIDTH = 300;

    const ZBX_TEXTAREA_TAG_WIDTH = 250;

    const ZBX_TEXTAREA_TAG_VALUE_WIDTH = 300;

    const ZBX_TEXTAREA_COLOR_WIDTH = 96;

    const ZBX_TEXTAREA_FILTER_SMALL_WIDTH = 150;

    const ZBX_TEXTAREA_FILTER_STANDARD_WIDTH = 300;

    const ZBX_TEXTAREA_TINY_WIDTH = 75;

    const ZBX_TEXTAREA_SMALL_WIDTH = 150;

    const ZBX_TEXTAREA_MEDIUM_WIDTH = 270;

    const ZBX_TEXTAREA_STANDARD_WIDTH = 453;

    const ZBX_TEXTAREA_BIG_WIDTH = 540;

    const ZBX_TEXTAREA_NUMERIC_STANDARD_WIDTH = 75;

    const ZBX_TEXTAREA_NUMERIC_BIG_WIDTH = 150;

    const ZBX_TEXTAREA_2DIGITS_WIDTH = 35;

    const ZBX_TEXTAREA_4DIGITS_WIDTH = 50;

    const ZBX_TEXTAREA_INTERFACE_IP_WIDTH = 225;

    const ZBX_TEXTAREA_INTERFACE_DNS_WIDTH = 175;

    const ZBX_TEXTAREA_INTERFACE_PORT_WIDTH = 100;

    const ZBX_TEXTAREA_STANDARD_ROWS = 7;

    const ZBX_HOST_INTERFACE_WIDTH = 750;

    const ZBX_OVERVIEW_HELP_MIN_WIDTH = 125;

    const ZBX_ACTION_ADD = 0;

    const ZBX_ACTION_REPLACE = 1;

    const ZBX_ACTION_REMOVE = 2;

    const ZBX_ACTIONS_POPUP_MAX_WIDTH = 800;

    const WIDGET_ACTION_LOG = 'actionlog';

    const WIDGET_CLOCK = 'clock';

    const WIDGET_DATA_OVER = 'dataover';

    const WIDGET_DISCOVERY = 'discovery';

    const WIDGET_FAV_GRAPHS = 'favgraphs';

    const WIDGET_FAV_MAPS = 'favmaps';

    const WIDGET_FAV_SCREENS = 'favscreens';

    const WIDGET_SVG_GRAPH = 'svggraph';

    const WIDGET_GRAPH = 'graph';

    const WIDGET_GRAPH_PROTOTYPE = 'graphprototype';

    const WIDGET_HOST_AVAIL = 'hostavail';

    const WIDGET_MAP = 'map';

    const WIDGET_NAV_TREE = 'navtree';

    const WIDGET_PLAIN_TEXT = 'plaintext';

    const WIDGET_PROBLEM_HOSTS = 'problemhosts';

    const WIDGET_PROBLEMS = 'problems';

    const WIDGET_PROBLEMS_BY_SV = 'problemsbysv';

    const WIDGET_SYSTEM_INFO = 'systeminfo';

    const WIDGET_TRIG_OVER = 'trigover';

    const WIDGET_URL = 'url';

    const WIDGET_WEB = 'web';

    const WIDGET_SYSMAP_SOURCETYPE_MAP = 1;

    const WIDGET_SYSMAP_SOURCETYPE_FILTER = 2;

    const WIDGET_FIELD_SELECT_RES_SYSMAP = 1;

    const WIDGET_NAVIGATION_TREE_MAX_DEPTH = 10;

    const WIDGET_HAT_TRIGGERDETAILS = 'hat_triggerdetails';

    const WIDGET_HAT_EVENTDETAILS = 'hat_eventdetails';

    const WIDGET_HAT_EVENTACTIONS = 'hat_eventactions';

    const WIDGET_HAT_EVENTLIST = 'hat_eventlist';

    const WIDGET_SEARCH_HOSTS = 'search_hosts';

    const WIDGET_SEARCH_HOSTGROUP = 'search_hostgroup';

    const WIDGET_SEARCH_TEMPLATES = 'search_templates';

    const WIDGET_SLIDESHOW = 'hat_slides';

    const WIDGET_SIMPLE_ITEM = 0;

    const WIDGET_DYNAMIC_ITEM = 1;

    const ZBX_WIDGET_ROWS = 20;

    const ZBX_WIDGET_FIELD_TYPE_INT32 = 0;

    const ZBX_WIDGET_FIELD_TYPE_STR = 1;

    const ZBX_WIDGET_FIELD_TYPE_GROUP = 2;

    const ZBX_WIDGET_FIELD_TYPE_HOST = 3;

    const ZBX_WIDGET_FIELD_TYPE_ITEM = 4;

    const ZBX_WIDGET_FIELD_TYPE_ITEM_PROTOTYPE = 5;

    const ZBX_WIDGET_FIELD_TYPE_GRAPH = 6;

    const ZBX_WIDGET_FIELD_TYPE_GRAPH_PROTOTYPE = 7;

    const ZBX_WIDGET_FIELD_TYPE_MAP = 8;

    const ZBX_WIDGET_FIELD_RESOURCE_GRAPH = 0;

    const ZBX_WIDGET_FIELD_RESOURCE_SIMPLE_GRAPH = 1;

    const ZBX_WIDGET_FIELD_RESOURCE_GRAPH_PROTOTYPE = 2;

    const ZBX_WIDGET_FIELD_RESOURCE_SIMPLE_GRAPH_PROTOTYPE = 3;

    const ZBX_WIDGET_VIEW_MODE_NORMAL = 0;

    const ZBX_WIDGET_VIEW_MODE_HIDDEN_HEADER = 1;

    const DB_ID = "({}>=0&&bccomp({},\"9223372036854775807\")<=0)&&";

    const NOT_EMPTY = "({}!='')&&";

    const NOT_ZERO = "({}!=0)&&";

    const ZBX_VALID_OK = 0;

    const ZBX_VALID_ERROR = 1;

    const ZBX_VALID_WARNING = 2;

    const THEME_DEFAULT = 'default';

    const ZBX_DEFAULT_THEME = 'blue-theme';

    const ZBX_DEFAULT_URL = 'zabbix.php?action=dashboard.view';

    const DATE_FORMAT_CONTEXT = 'Date format (see http://php.net/date)';

    const AVAILABILITY_REPORT_BY_HOST = 0;

    const AVAILABILITY_REPORT_BY_TEMPLATE = 1;

    const ZBX_MONITORED_BY_ANY = 0;

    const ZBX_MONITORED_BY_SERVER = 1;

    const ZBX_MONITORED_BY_PROXY = 2;

    const QUEUE_OVERVIEW = 0;

    const QUEUE_OVERVIEW_BY_PROXY = 1;

    const QUEUE_DETAILS = 2;

    const QUEUE_DETAIL_ITEM_COUNT = 500;

    const COPY_TYPE_TO_HOST_GROUP = 0;

    const COPY_TYPE_TO_HOST = 1;

    const COPY_TYPE_TO_TEMPLATE = 2;

    const HISTORY_GRAPH = 'showgraph';

    const HISTORY_BATCH_GRAPH = 'batchgraph';

    const HISTORY_VALUES = 'showvalues';

    const HISTORY_LATEST = 'showlatest';

    const ITEM_STORAGE_OFF = 0;

    const ITEM_STORAGE_CUSTOM = 1;

    const ITEM_NO_STORAGE_VALUE = 0;

    const MAP_DEFAULT_ICON = 'Server_(96)';

    const ZBX_PROPERTY_INHERITED = 0x01;

    const ZBX_PROPERTY_OWN = 0x02;

    const ZBX_PROPERTY_BOTH = 0x03;

    const PROBLEMS_SHOW_TAGS_NONE = 0;

    const PROBLEMS_SHOW_TAGS_1 = 1;

    const PROBLEMS_SHOW_TAGS_2 = 2;

    const PROBLEMS_SHOW_TAGS_3 = 3;

    const PROBLEMS_TAG_NAME_FULL = 0;

    const PROBLEMS_TAG_NAME_SHORTENED = 1;

    const PROBLEMS_TAG_NAME_NONE = 2;

    const OPERATIONAL_DATA_SHOW_NONE = 0;

    const OPERATIONAL_DATA_SHOW_SEPARATELY = 1;

    const OPERATIONAL_DATA_SHOW_WITH_PROBLEM = 2;

    const X_FRAME_OPTIONS = 'SAMEORIGIN';
```
</details>