### PR TITLE
Avoid to retrieve a bigger payload than required at `userLogin()`

### DIFF
--- a/build/templates/abstract.tpl.php
+++ b/build/templates/abstract.tpl.php
@@ -433,7 +433,7 @@ abstract class <CLASSNAME_ABSTRACT>
             try {
                 // get auth token and try to execute a user.get (dummy check)
                 $this->authToken = file_get_contents($tokenCacheFile);
-                $this->userGet();
+                $this->userGet(array('countOutput' => true));
             } catch (Exception $e) {
                 // user.get failed, token invalid so reset it and remove file
                 $this->authToken = '';


### PR DESCRIPTION
Since `userGet()` is only called to check if authentication is required, the resulting output is not required. Retrieving just the count instead of the full user list is more efficient.