### PR TITLE
Do not call `userLogin()` at `__construct()`

### DIFF
--- a/build/templates/abstract.tpl.php
+++ b/build/templates/abstract.tpl.php
@@ -56,6 +56,16 @@ abstract class <CLASSNAME_ABSTRACT>
     private $defaultParams = array();
 
     /**
+     * @var string
+     */
+    private $user;
+
+    /**
+     * @var string
+     */
+    private $password;
+
+    /**
      * Auth string.
      *
      * @var string
@@ -137,7 +147,8 @@ abstract class <CLASSNAME_ABSTRACT>
         if ($authToken) {
             $this->setAuthToken($authToken);
         } elseif ($user && $password) {
-            $this->userLogin(array('user' => $user, 'password' => $password));
+            $this->user = $user;
+            $this->password = $password;
         }
     }
 
@@ -270,6 +281,10 @@ abstract class <CLASSNAME_ABSTRACT>
      */
     public function request($method, $params = null, $resultArrayKey = '', $auth = true)
     {
+        if (!$this->authToken && $auth && $this->user && $this->password) {
+            $this->userLogin(array('user' => $this->user, 'password' => $this->password));
+        }
+
         // sanity check and conversion for params array
         if (!$params) {
             $params = array();

--- a/tests/ZabbixApiTest.php
+++ b/tests/ZabbixApiTest.php
@@ -41,7 +41,7 @@ final class ZabbixApiTest extends TestCase
 
         $this->assertGreaterThanOrEqual(0, version_compare(ZabbixApi::ZABBIX_VERSION, '2.4'));
 
-        $zabbix = new ZabbixApi('http://localhost/json_rpc.php');
+        $zabbix = new ZabbixApi('http://localhost/json_rpc.php', 'zabbix', 'very_secret');
 
         $defaultParams = array(
             'some_param' => array('one'),
@@ -170,22 +170,15 @@ final class ZabbixApiTest extends TestCase
         );
     }
 
-    public function testZabbixApiConnectionNotTriggered()
-    {
-        $zabbix = new ZabbixApi('http://localhost/json_rpc.php');
-        $zabbix = new ZabbixApi('http://localhost/json_rpc.php', 'zabbix');
-        $zabbix = new ZabbixApi('http://localhost/json_rpc.php', '', 'very_secret');
-
-        $this->assertSame('http://localhost/json_rpc.php', $zabbix->getApiUrl());
-    }
-
     /**
      * @expectedException \ZabbixApi\Exception
      * @expectedExceptionMessage Could not connect to "http://not.found.tld/json_rpc.php"
      */
     public function testZabbixApiConnectionError()
     {
-        new ZabbixApi('http://not.found.tld/json_rpc.php', 'zabbix', 'very_secret_pass');
+        $zabbix = new ZabbixApi('http://not.found.tld/json_rpc.php', 'zabbix', 'very_secret');
+
+        $zabbix->userGet();
     }
 
     /**


### PR DESCRIPTION
These changes avoid to call `userLogin()` at `__construct()`, allowing the class to be instantiated without firing any request.

@clevelas, @jaffog; if you can, please test the results.

Closes #38.