### PR TITLE
Add suggestion for "ext-posix"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "friendsofphp/php-cs-fixer": "^1.13|^2.16",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
     },
+    "suggest": {
+        "ext-posix": "In order to get the real user ID of the current process."
+    },
     "autoload": {
         "psr-4": { "ZabbixApi\\": ["src/"] }
     },


### PR DESCRIPTION
`userLogin()` method calls `posix_getuid()` if the function is available:
https://github.com/confirm/PhpZabbixApi/blob/a5944bbbcc6e69dde39732601e2542ff725d64f6/build/templates/abstract.tpl.php#L427