### PR TITLE
Make authentication check for each API method explicit at build time

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -230,12 +230,18 @@ foreach ($constantsArray['constant_names'] as $k => $name) {
 // initialize variable for API methods
 $apiMethods = '';
 
+$anonymousFunctions = array(
+    'apiinfo.version',
+);
+
 // build API methods
 foreach ($apiArray as $resource => $actions) {
     foreach ($actions as $action) {
+        $apiMethod = $resource.'.'.$action;
         $methodPlaceholders = array(
-            'API_METHOD' => $resource.'.'.$action,
+            'API_METHOD' => $apiMethod,
             'PHP_METHOD' => $resource.ucfirst($action),
+            'IS_AUTHENTICATION_REQUIRED' => in_array($apiMethod, $anonymousFunctions, true) ? 'false' : 'true',
         );
         $apiMethods .= replacePlaceholders($matches[4], $methodPlaceholders);
     }

--- a/build/templates/abstract.tpl.php
+++ b/build/templates/abstract.tpl.php
@@ -35,15 +35,6 @@ abstract class <CLASSNAME_ABSTRACT>
     const <PHP_CONST_NAME> = <PHP_CONST_VALUE>;
 <!END_API_CONSTANT>
     /**
-     * Anonymous API functions.
-     *
-     * @var string[]
-     */
-    private static $anonymousFunctions = array(
-        'apiinfo.version',
-    );
-
-    /**
      * Boolean if requests/responses should be printed out (JSON).
      *
      * @var bool
@@ -210,7 +201,7 @@ abstract class <CLASSNAME_ABSTRACT>
     /**
      * Sets the context for SSL-enabled connections.
      *
-     * @see http://php.net/manual/en/context.ssl.php.
+     * @see https://php.net/manual/en/context.ssl.php.
      *
      * @param array $context Array with the SSL context
      *
@@ -490,7 +481,7 @@ abstract class <CLASSNAME_ABSTRACT>
     }
 <!START_API_METHOD>
     /**
-     * Requests the Zabbix API and returns the response of the API method "<API_METHOD>".
+     * Requests the Zabbix API and returns the response of the method "<API_METHOD>".
      *
      * The $params Array can be used, to pass parameters to the Zabbix API.
      * For more information about these parameters, check the Zabbix API
@@ -510,14 +501,7 @@ abstract class <CLASSNAME_ABSTRACT>
      */
     public function <PHP_METHOD>($params = array(), $arrayKeyProperty = '')
     {
-        // get params array for request
-        $params = $this->getRequestParamsArray($params);
-
-        // check if we've to authenticate
-        $auth = !in_array('<API_METHOD>', self::$anonymousFunctions, true);
-
-        // request
-        return $this->request('<API_METHOD>', $params, $arrayKeyProperty, $auth);
+        return $this->request('<API_METHOD>', $this->getRequestParamsArray($params), $arrayKeyProperty, <IS_AUTHENTICATION_REQUIRED>);
     }
 <!END_API_METHOD>
     /**

--- a/tests/ZabbixApiTest.php
+++ b/tests/ZabbixApiTest.php
@@ -135,6 +135,41 @@ final class ZabbixApiTest extends TestCase
         $this->removeTokenCacheDir($cacheDir);
     }
 
+    /**
+     * @dataProvider getAuthenticationRequired
+     *
+     * @param string $method
+     * @param string $apiMethod
+     * @param bool $isAuthenticationRequired
+     */
+    public function testAuthenticationRequired($method, $apiMethod, $isAuthenticationRequired)
+    {
+        $this->assertTrue(is_callable(array('ZabbixApi\ZabbixApi', $method)));
+
+        $zabbix = $this->getMockBuilder('ZabbixApi\ZabbixApi')
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->setMethods(array('request'))
+            ->getMock();
+
+        $zabbix
+            ->expects($this->once())
+            ->method('request')
+            ->with($apiMethod, array(), '', $isAuthenticationRequired);
+
+        $zabbix->$method();
+    }
+
+    public function getAuthenticationRequired()
+    {
+        return array(
+            array('method' => 'userGet', 'api_method' => 'user.get', 'is_authentication_required' => true),
+            array('method' => 'apiinfoVersion', 'api_method' => 'apiinfo.version', 'is_authentication_required' => false),
+            array('method' => 'hostGet', 'api_method' => 'host.get', 'is_authentication_required' => true),
+        );
+    }
+
     public function testZabbixApiConnectionNotTriggered()
     {
         $zabbix = new ZabbixApi('http://localhost/json_rpc.php');


### PR DESCRIPTION
Since at build time we know if a method requires or not authentication based in their name, build the methods including the resolved value instead of checking that at running time.

**BEFORE**:
```php
// get params array for request
$params = $this->getRequestParamsArray($params);

// check if we've to authenticate
$auth = !in_array('apiinfo.version', self::$anonymousFunctions, true);

// request
return $this->request('apiinfo.version', $params, $arrayKeyProperty, $auth);
```
**AFTER**:
```php
return $this->request('apiinfo.version', $this->getRequestParamsArray($params), $arrayKeyProperty, false);
```